### PR TITLE
[Task#66965] show multiple warning when lessons has updated

### DIFF
--- a/resources/views/learning/show.blade.php
+++ b/resources/views/learning/show.blade.php
@@ -93,8 +93,7 @@
                             </div>
 
                             <div class="mt-5 flex items-center space-x-4">
-                                <img class="h-8 w-8 rounded-full" src="{{ $teacher->avatar }}"
-                                        alt="avatar">
+                                <img class="h-8 w-8 rounded-full" src="{{ $teacher->avatar }}" alt="avatar">
                                 <div class="font-medium dark:text-white">
                                     <div>{{ $teacher->name }}</div>
                                 </div>
@@ -127,7 +126,18 @@
                     });
                 </script>
             @endif
+
+            @if (session()->has('warning_messages'))
+                @foreach (session('warning_messages') as $message)
+                    <script>
+                        window.addEventListener('load', function() {
+                            toastr.warning('{{ $message }}');
+                        });
+                    </script>
+                @endforeach
+            @endif
         </div>
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
<!--
  PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.
-->

## Related Tickets:
- [#Ticket 66965](https://edu-redmine.sun-asterisk.vn/issues/66965)

## WHAT this PR does?
<!--
- ex: Change number items `completed/total` in admin page.
-->
- Fix bug not show warning when the teacher has updated the lesson that the user has learned
## Notes Impacted Areas:
- N/A.

## Attachments:
- 
![image](https://github.com/awesome-academy/Naitei-202307-E-Learning/assets/137484861/4f880a99-acc2-46ca-a0d3-61720b07103f)

